### PR TITLE
fixOrientation Extension for UIImage

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,10 @@
 
 		<header-file src="src/ios/SOSPicker.h" />
 		<source-file src="src/ios/SOSPicker.m" />
-
+        
+        <header-file src="src/ios/GMImagePicker/UIImage+fixOrientation.h" />
+        <source-file src="src/ios/GMImagePicker/UIImage+fixOrientation.m" />
+        
 		<header-file src="src/ios/GMImagePicker/GMAlbumsViewCell.h" />
 		<source-file src="src/ios/GMImagePicker/GMAlbumsViewCell.m" />
 

--- a/src/ios/GMImagePicker/GMGridViewController.h
+++ b/src/ios/GMImagePicker/GMGridViewController.h
@@ -8,7 +8,7 @@
 
 
 #import "GMImagePickerController.h"
-
+#import "UIImage+fixOrientation.m"
 
 #import <Photos/Photos.h>
 

--- a/src/ios/GMImagePicker/GMGridViewController.m
+++ b/src/ios/GMImagePicker/GMGridViewController.m
@@ -451,7 +451,7 @@ NSString * const GMGridViewCellIdentifier = @"GMGridViewCellIdentifier";
         [ ph_options setNetworkAccessAllowed:YES];
         
         // @BVL Set Deliverymode, in order to return highest quality
-		[ ph_options setDeliveryMode: PHImageRequestOptionsDeliveryModeFastFormat ]; // Best Quality
+		[ ph_options setDeliveryMode: PHImageRequestOptionsDeliveryModeHighQualityFormat ]; // Best Quality
 
         [ ph_options setProgressHandler:^(double progress, NSError *error, BOOL *stop, NSDictionary *info) {
             

--- a/src/ios/GMImagePicker/GMGridViewController.m
+++ b/src/ios/GMImagePicker/GMGridViewController.m
@@ -492,7 +492,20 @@ NSString * const GMGridViewCellIdentifier = @"GMGridViewCellIdentifier";
             
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                 
-                if ( ![ UIImageJPEGRepresentation(result, 1.0f ) writeToFile:filePath atomically:YES ] ) {
+                
+                // @BVL: Added orientation-fix to correctly display the returned result
+                
+//              if ( ![ UIImageJPEGRepresentation(result, 1.0f ) writeToFile:filePath atomically:YES ] ) {
+//                  return;
+//              }
+                
+                NSLog(@"original orientation: %ld",(UIImageOrientation)result.imageOrientation);
+                
+                UIImage *imageToDisplay = result.fixOrientation; //  UIImage+fixOrientation extension
+                
+          		NSLog(@"corrected orientation: %ld",(UIImageOrientation)imageToDisplay.imageOrientation);
+
+                if ( ![ UIImageJPEGRepresentation(imageToDisplay, 1.0f ) writeToFile:filePath atomically:YES ] ) {
                     return;
                 }
                 

--- a/src/ios/GMImagePicker/GMGridViewController.m
+++ b/src/ios/GMImagePicker/GMGridViewController.m
@@ -449,6 +449,10 @@ NSString * const GMGridViewCellIdentifier = @"GMGridViewCellIdentifier";
         PHImageRequestOptions *ph_options = [[PHImageRequestOptions alloc] init];
         
         [ ph_options setNetworkAccessAllowed:YES];
+        
+        // @BVL Set Deliverymode, in order to return highest quality
+		[ ph_options setDeliveryMode: PHImageRequestOptionsDeliveryModeFastFormat ]; // Best Quality
+
         [ ph_options setProgressHandler:^(double progress, NSError *error, BOOL *stop, NSDictionary *info) {
             
             fetch_item.percent = progress;

--- a/src/ios/GMImagePicker/UIImage+fixOrientation.h
+++ b/src/ios/GMImagePicker/UIImage+fixOrientation.h
@@ -1,0 +1,5 @@
+@interface UIImage(fixOrientation)
+
+- (UIImage *)fixOrientation;
+
+@end

--- a/src/ios/GMImagePicker/UIImage+fixOrientation.m
+++ b/src/ios/GMImagePicker/UIImage+fixOrientation.m
@@ -1,0 +1,15 @@
+#import "UIImage+fixOrientation.h"
+
+@implementation UIImage (fixOrientation)
+
+- (UIImage *)fixOrientation {
+    if (self.imageOrientation == UIImageOrientationUp) return self; 
+
+    UIGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
+    [self drawInRect:(CGRect){0, 0, self.size}];
+    UIImage *normalizedImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return normalizedImage;
+}
+
+@end


### PR DESCRIPTION
By default, IOS does not respect the original orientation in which the Photo was taken.
(Sometimes the returned photo's are upside-down, rotated -90 degrees etc.)

The fixOrientation extension corrects this.